### PR TITLE
FCE-38: Execute Query and Mutation

### DIFF
--- a/app/graphql/mutations/car/create_car.rb
+++ b/app/graphql/mutations/car/create_car.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Mutations
+  module Car
+    class CreateCar < Mutations::BaseMutation
+      argument :car, Types::Inputs::CarInputType, required: true
+
+      field :car, Types::CarType, null: true
+      field :errors, [String], null: false
+
+      def resolve(car:)
+        new_car = ::Car.new(car.to_h)
+
+        if new_car.save
+          { car: new_car, errors: [] }
+        else
+          { car: nil, errors: new_car.errors.full_messages }
+        end
+      end
+    end
+  end
+end

--- a/app/graphql/resolvers/cars/cars_resolver.rb
+++ b/app/graphql/resolvers/cars/cars_resolver.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Resolvers
+  module Cars
+    class CarsResolver < Types::Common::SearchableQueryType
+      description "Get all cars"
+
+      scope { ::Car.all }
+
+      option :num_of_doors, type: Integer, required: false, with: :apply_num_of_doors
+      option :min_doors, type: Integer, required: false, with: :apply_min_doors
+      option :max_doors, type: Integer, required: false, with: :apply_max_doors
+
+      type [Types::CarType], null: true
+
+      def apply_num_of_doors(scope, value)
+        value.present? ? scope.where(num_of_doors: value) : scope
+      end
+
+      def apply_min_doors(scope, value)
+        value.present? ? scope.where("num_of_doors >= ?", value) : scope
+      end
+
+      def apply_max_doors(scope, value)
+        value.present? ? scope.where("num_of_doors <= ?", value) : scope
+      end
+    end
+  end
+end

--- a/app/graphql/types/car_type.rb
+++ b/app/graphql/types/car_type.rb
@@ -6,5 +6,7 @@ module Types
     implements Types::VehicleType
 
     field :num_of_doors, Integer, null: false
+    field :min_doors, Integer, null: true
+    field :max_doors, Integer, null: true
   end
 end

--- a/app/graphql/types/inputs/car_input_type.rb
+++ b/app/graphql/types/inputs/car_input_type.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Types
+  module Inputs
+    class CarInputType < Types::BaseInputObject
+      argument :brand_id, Integer, required: true
+      argument :model, String, required: true
+      argument :num_of_doors, Integer, required: true
+      argument :amount, Float, required: true
+      argument :currency, String, required: true
+    end
+  end
+end

--- a/app/graphql/types/mutation_type.rb
+++ b/app/graphql/types/mutation_type.rb
@@ -4,5 +4,6 @@ module Types
   class MutationType < Types::BaseObject
     field :create_brand, mutation: Mutations::Brand::CreateBrand
     field :create_bike, mutation: Mutations::Bike::CreateBike
+    field :create_car, mutation: Mutations::Car::CreateCar
   end
 end

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -4,6 +4,7 @@ module Types
   class QueryType < Types::BaseObject
     field :get_brands, resolver: Resolvers::Brands::BrandsResolver
     field :get_bikes, resolver: Resolvers::Bikes::BikesResolver
+    field :get_cars, resolver: Resolvers::Cars::CarsResolver
     field :vehicles, [Types::VehicleUnion], null: false
 
     def vehicles


### PR DESCRIPTION
## Summary  
Implemented **GraphQL support for Car model** in line with the existing Bike setup. This adds query, mutation, input type, resolver, and schema integration for the `Car` entity.  

---

## Changes  
- **CarType**: ensured the GraphQL type implements `PriceType` and `VehicleType`, with a `num_of_doors` field.  
- **Input object**: added `CarInputType` with arguments (`brand_id`, `model`, `num_of_doors`, `amount`, `currency`).  
- **Mutation**: created `Mutations::Car::CreateCar` for adding new cars.  
- **Resolver**: added `Resolvers::Cars::CarsResolver` for fetching cars, with optional filtering by `num_of_doors`.  
- **Schema updates**:  
  - Added `createCar` mutation.  
  - Added `getCars` query.  

---

## Testing  
- Verified creation of new cars via GraphQL mutation.  
- Queried cars with and without filters (`num_of_doors`) through GraphiQL.  
- Confirmed union type resolution now supports both `CarType` and `BikeType`.  

---

## Task Reference  
- **Task ID**: FCE-38  
- **Task Link**: [Notion Doc](https://www.notion.so/rev365/CJ-self-study-GraphQL-268f0888578b8022a773d89b21160279?v=1a8f0888578b81afad13000c4d1c070a&source=copy_link) 